### PR TITLE
added default values for titiler

### DIFF
--- a/src/titiler/core/titiler/core/dependencies.py
+++ b/src/titiler/core/titiler/core/dependencies.py
@@ -58,7 +58,15 @@ def create_colormap_dependency(cmap: ColorMaps) -> Callable:
 ColorMapParams = create_colormap_dependency(default_cmap)
 
 
-def DatasetPathParams(url: Annotated[str, Query(description="Dataset URL")]) -> str:
+def DatasetPathParams(
+    url: Annotated[
+        str,
+        Query(
+            description="Dataset URL",
+            example="https://dap.ceda.ac.uk/neodc/sentinel_ard/data/sentinel_2/2023/11/21/S2B_20231121_latn536lonw0052_T30UUE_ORB123_20231121122846_utm30n_TM65_vmsk_sharp_rad_srefdem_stdsref.tif",
+        ),
+    ],
+) -> str:
     """Create dataset path from args"""
     return url
 
@@ -468,9 +476,9 @@ class ImageRenderingParams(DefaultDependency):
                         r.replace(" ", "").replace("[", "").replace("]", "").split(","),
                     )
                 )
-                assert (
-                    len(parsed) == 2
-                ), f"Invalid rescale values: {self.rescale}, should be of form ['min,max', 'min,max'] or [[min,max], [min, max]]"
+                assert len(parsed) == 2, (
+                    f"Invalid rescale values: {self.rescale}, should be of form ['min,max', 'min,max'] or [[min,max], [min, max]]"
+                )
                 rescale_array.append(parsed)
 
             self.rescale: RescaleType = rescale_array
@@ -501,9 +509,9 @@ def RescalingParams(
                     r.replace(" ", "").replace("[", "").replace("]", "").split(","),
                 )
             )
-            assert (
-                len(parsed) == 2
-            ), f"Invalid rescale values: {rescale}, should be of form ['min,max', 'min,max'] or [[min,max], [min, max]]"
+            assert len(parsed) == 2, (
+                f"Invalid rescale values: {rescale}, should be of form ['min,max', 'min,max'] or [[min,max], [min, max]]"
+            )
 
             rescale_array.append(parsed)
 
@@ -608,9 +616,9 @@ link: https://numpy.org/doc/stable/reference/generated/numpy.histogram.html
 
         if self.range:
             parsed = list(map(float, self.range.split(",")))
-            assert (
-                len(parsed) == 2
-            ), f"Invalid histogram_range values: {self.range}, should be of form 'min,max'"
+            assert len(parsed) == 2, (
+                f"Invalid histogram_range values: {self.range}, should be of form 'min,max'"
+            )
 
             self.range = parsed  # type: ignore
 
@@ -620,9 +628,10 @@ def CoordCRSParams(
         Optional[str],
         Query(
             alias="coord_crs",
+            example="EPSG:4326",
             description="Coordinate Reference System of the input coords. Default to `epsg:4326`.",
         ),
-    ] = None,
+    ] = "EPSG:4326",
 ) -> Optional[CRS]:
     """Coordinate Reference System Coordinates Param."""
     if crs:
@@ -652,6 +661,7 @@ def CRSParams(
         Optional[str],
         Query(
             description="Coordinate Reference System.",
+            example="EPSG:4326",
         ),
     ] = None,
 ) -> Optional[CRS]:

--- a/src/titiler/core/titiler/core/factory.py
+++ b/src/titiler/core/titiler/core/factory.py
@@ -347,11 +347,13 @@ class TilerFactory(BaseFactory):
             env=Depends(self.environment_dependency),
         ):
             """Return the bounds of the COG."""
-            resolved_path, updated_env = resolve_src_path_and_credentials(src_path, request, env)
+            resolved_path, updated_env = resolve_src_path_and_credentials(
+                src_path, request, env
+            )
             extra_kwargs = {}
 
             if self.reader == XarrayReader:
-                extra_kwargs['request_options'] = request.headers
+                extra_kwargs["request_options"] = request.headers
 
             with rasterio.Env(**updated_env):
                 with self.reader(
@@ -383,11 +385,13 @@ class TilerFactory(BaseFactory):
             env=Depends(self.environment_dependency),
         ):
             """Return dataset's basic info."""
-            resolved_path, updated_env = resolve_src_path_and_credentials(src_path, request, env)
+            resolved_path, updated_env = resolve_src_path_and_credentials(
+                src_path, request, env
+            )
             extra_kwargs = {}
 
             if self.reader == XarrayReader:
-                extra_kwargs['request_options'] = request.headers
+                extra_kwargs["request_options"] = request.headers
 
             with rasterio.Env(**updated_env):
                 with self.reader(
@@ -415,11 +419,13 @@ class TilerFactory(BaseFactory):
             env=Depends(self.environment_dependency),
         ):
             """Return dataset's basic info as a GeoJSON feature."""
-            resolved_path, updated_env = resolve_src_path_and_credentials(src_path, request, env)
+            resolved_path, updated_env = resolve_src_path_and_credentials(
+                src_path, request, env
+            )
             extra_kwargs = {}
 
             if self.reader == XarrayReader:
-                extra_kwargs['request_options'] = request.headers
+                extra_kwargs["request_options"] = request.headers
 
             with rasterio.Env(**updated_env):
                 with self.reader(
@@ -466,11 +472,13 @@ class TilerFactory(BaseFactory):
             env=Depends(self.environment_dependency),
         ):
             """Get Dataset statistics."""
-            resolved_path, updated_env = resolve_src_path_and_credentials(src_path, request, env)
+            resolved_path, updated_env = resolve_src_path_and_credentials(
+                src_path, request, env
+            )
             extra_kwargs = {}
 
             if self.reader == XarrayReader:
-                extra_kwargs['request_options'] = request.headers
+                extra_kwargs["request_options"] = request.headers
 
             with rasterio.Env(**updated_env):
                 with self.reader(
@@ -526,11 +534,13 @@ class TilerFactory(BaseFactory):
             if isinstance(fc, Feature):
                 fc = FeatureCollection(type="FeatureCollection", features=[geojson])
 
-            resolved_path, updated_env = resolve_src_path_and_credentials(src_path, request, env)
+            resolved_path, updated_env = resolve_src_path_and_credentials(
+                src_path, request, env
+            )
             extra_kwargs = {}
 
             if self.reader == XarrayReader:
-                extra_kwargs['request_options'] = request.headers
+                extra_kwargs["request_options"] = request.headers
 
             with rasterio.Env(**updated_env):
                 with self.reader(
@@ -596,11 +606,13 @@ class TilerFactory(BaseFactory):
             env=Depends(self.environment_dependency),
         ):
             """Retrieve a list of available raster tilesets for the specified dataset."""
-            resolved_path, updated_env = resolve_src_path_and_credentials(src_path, request, env)
+            resolved_path, updated_env = resolve_src_path_and_credentials(
+                src_path, request, env
+            )
             extra_kwargs = {}
 
             if self.reader == XarrayReader:
-                extra_kwargs['request_options'] = request.headers
+                extra_kwargs["request_options"] = request.headers
 
             with rasterio.Env(**updated_env):
                 with self.reader(
@@ -695,13 +707,15 @@ class TilerFactory(BaseFactory):
         ):
             """Retrieve the raster tileset metadata for the specified dataset and tiling scheme (tile matrix set)."""
             tms = self.supported_tms.get(tileMatrixSetId)
-            resolved_path, updated_env = resolve_src_path_and_credentials(src_path, request, env)
+            resolved_path, updated_env = resolve_src_path_and_credentials(
+                src_path, request, env
+            )
             extra_kwargs = {
-                'tms' : tms,
+                "tms": tms,
             }
 
             if self.reader == XarrayReader:
-                extra_kwargs['request_options'] = request.headers
+                extra_kwargs["request_options"] = request.headers
 
             with rasterio.Env(**updated_env):
                 with self.reader(
@@ -833,18 +847,21 @@ class TilerFactory(BaseFactory):
                 int,
                 Path(
                     description="Identifier (Z) selecting one of the scales defined in the TileMatrixSet and representing the scaleDenominator the tile.",
+                    example="0",
                 ),
             ],
             x: Annotated[
                 int,
                 Path(
                     description="Column (X) index of the tile on the selected TileMatrix. It cannot exceed the MatrixHeight-1 for the selected TileMatrix.",
+                    example="0",
                 ),
             ],
             y: Annotated[
                 int,
                 Path(
                     description="Row (Y) index of the tile on the selected TileMatrix. It cannot exceed the MatrixWidth-1 for the selected TileMatrix.",
+                    example="0",
                 ),
             ],
             tileMatrixSetId: Annotated[
@@ -856,7 +873,10 @@ class TilerFactory(BaseFactory):
             scale: Annotated[
                 int,
                 Field(
-                    gt=0, le=4, description="Tile size scale. 1=256x256, 2=512x512..."
+                    gt=0,
+                    le=4,
+                    description="Tile size scale. 1=256x256, 2=512x512...",
+                    example="2",
                 ),
             ] = 1,
             format: Annotated[
@@ -875,11 +895,13 @@ class TilerFactory(BaseFactory):
         ):
             """Create map tile from a dataset."""
             tms = self.supported_tms.get(tileMatrixSetId)
-            resolved_path, updated_env = resolve_src_path_and_credentials(src_path, request, env)
-            extra_kwargs = {'tms': tms}
+            resolved_path, updated_env = resolve_src_path_and_credentials(
+                src_path, request, env
+            )
+            extra_kwargs = {"tms": tms}
 
             if self.reader == XarrayReader:
-                extra_kwargs['request_options'] = request.headers
+                extra_kwargs["request_options"] = request.headers
 
             with rasterio.Env(**updated_env):
                 with self.reader(
@@ -909,12 +931,8 @@ class TilerFactory(BaseFactory):
             return Response(content, media_type=media_type)
 
         @self.router.get(r"/tiles/{z}/{x}/{y}", **img_endpoint_params)
-        @self.router.get(
-            r"/tiles/{z}/{x}/{y}.{format}", **img_endpoint_params
-        )
-        @self.router.get(
-            r"/tiles/{z}/{x}/{y}@{scale}x", **img_endpoint_params
-        )
+        @self.router.get(r"/tiles/{z}/{x}/{y}.{format}", **img_endpoint_params)
+        @self.router.get(r"/tiles/{z}/{x}/{y}@{scale}x", **img_endpoint_params)
         @self.router.get(
             r"/tiles/{z}/{x}/{y}@{scale}x.{format}",
             **img_endpoint_params,
@@ -1054,11 +1072,13 @@ class TilerFactory(BaseFactory):
                 tiles_url += f"?{urlencode(qs)}"
 
             tms = self.supported_tms.get(tileMatrixSetId)
-            resolved_path, updated_env = resolve_src_path_and_credentials(src_path, request, env)
-            extra_kwargs = {'tms': tms}
+            resolved_path, updated_env = resolve_src_path_and_credentials(
+                src_path, request, env
+            )
+            extra_kwargs = {"tms": tms}
 
             if self.reader == XarrayReader:
-                extra_kwargs['request_options'] = request.headers
+                extra_kwargs["request_options"] = request.headers
 
             with rasterio.Env(**updated_env):
                 with self.reader(
@@ -1262,11 +1282,13 @@ class TilerFactory(BaseFactory):
             ]
 
             tms = self.supported_tms.get(tileMatrixSetId)
-            resolved_path, updated_env = resolve_src_path_and_credentials(src_path, request, env)
-            extra_kwargs = {'tms': tms}
+            resolved_path, updated_env = resolve_src_path_and_credentials(
+                src_path, request, env
+            )
+            extra_kwargs = {"tms": tms}
 
             if self.reader == XarrayReader:
-                extra_kwargs['request_options'] = request.headers
+                extra_kwargs["request_options"] = request.headers
 
             with rasterio.Env(**updated_env):
                 with self.reader(
@@ -1356,11 +1378,13 @@ class TilerFactory(BaseFactory):
         ):
             """Get Point value for a dataset."""
 
-            resolved_path, updated_env = resolve_src_path_and_credentials(src_path, request, env)
+            resolved_path, updated_env = resolve_src_path_and_credentials(
+                src_path, request, env
+            )
             extra_kwargs = {}
 
             if self.reader == XarrayReader:
-                extra_kwargs['request_options'] = request.headers
+                extra_kwargs["request_options"] = request.headers
 
             with rasterio.Env(**updated_env):
                 with self.reader(
@@ -1405,12 +1429,13 @@ class TilerFactory(BaseFactory):
             render_params=Depends(self.render_dependency),
             env=Depends(self.environment_dependency),
         ):
-            
-            resolved_path, updated_env = resolve_src_path_and_credentials(src_path, request, env)
+            resolved_path, updated_env = resolve_src_path_and_credentials(
+                src_path, request, env
+            )
             extra_kwargs = {}
 
             if self.reader == XarrayReader:
-                extra_kwargs['request_options'] = request.headers
+                extra_kwargs["request_options"] = request.headers
 
             with rasterio.Env(**updated_env):
                 with self.reader(
@@ -1474,11 +1499,13 @@ class TilerFactory(BaseFactory):
             env=Depends(self.environment_dependency),
         ):
             """Create image from a bbox."""
-            resolved_path, updated_env = resolve_src_path_and_credentials(src_path, request, env)
+            resolved_path, updated_env = resolve_src_path_and_credentials(
+                src_path, request, env
+            )
             extra_kwargs = {}
 
             if self.reader == XarrayReader:
-                extra_kwargs['request_options'] = request.headers
+                extra_kwargs["request_options"] = request.headers
 
             with rasterio.Env(**updated_env):
                 with self.reader(
@@ -1539,11 +1566,13 @@ class TilerFactory(BaseFactory):
             env=Depends(self.environment_dependency),
         ):
             """Create image from a geojson feature."""
-            resolved_path, updated_env = resolve_src_path_and_credentials(src_path, request, env)
+            resolved_path, updated_env = resolve_src_path_and_credentials(
+                src_path, request, env
+            )
             extra_kwargs = {}
 
             if self.reader == XarrayReader:
-                extra_kwargs['request_options'] = request.headers
+                extra_kwargs["request_options"] = request.headers
 
             with rasterio.Env(**updated_env):
                 with self.reader(
@@ -1618,11 +1647,13 @@ class MultiBaseTilerFactory(TilerFactory):
             env=Depends(self.environment_dependency),
         ):
             """Return dataset's basic info or the list of available assets."""
-            resolved_path, updated_env = resolve_src_path_and_credentials(src_path, request, env)
+            resolved_path, updated_env = resolve_src_path_and_credentials(
+                src_path, request, env
+            )
             extra_kwargs = {}
 
             if self.reader == XarrayReader:
-                extra_kwargs['request_options'] = request.headers
+                extra_kwargs["request_options"] = request.headers
 
             with rasterio.Env(**updated_env):
                 with self.reader(
@@ -1676,10 +1707,12 @@ class MultiBaseTilerFactory(TilerFactory):
             """Return a list of supported assets."""
             extra_kwargs = {}
 
-            resolved_path, updated_env = resolve_src_path_and_credentials(src_path, request, env)
+            resolved_path, updated_env = resolve_src_path_and_credentials(
+                src_path, request, env
+            )
 
             if self.reader == XarrayReader:
-                extra_kwargs['request_options'] = request.headers
+                extra_kwargs["request_options"] = request.headers
 
             with rasterio.Env(**updated_env):
                 with self.reader(
@@ -1716,11 +1749,13 @@ class MultiBaseTilerFactory(TilerFactory):
             env=Depends(self.environment_dependency),
         ):
             """Per Asset statistics"""
-            resolved_path, updated_env = resolve_src_path_and_credentials(src_path, request, env)
+            resolved_path, updated_env = resolve_src_path_and_credentials(
+                src_path, request, env
+            )
             extra_kwargs = {}
 
             if self.reader == XarrayReader:
-                extra_kwargs['request_options'] = request.headers
+                extra_kwargs["request_options"] = request.headers
 
             with rasterio.Env(**updated_env):
                 with self.reader(
@@ -1761,11 +1796,13 @@ class MultiBaseTilerFactory(TilerFactory):
             env=Depends(self.environment_dependency),
         ):
             """Merged assets statistics."""
-            resolved_path, updated_env = resolve_src_path_and_credentials(src_path, request, env)
+            resolved_path, updated_env = resolve_src_path_and_credentials(
+                src_path, request, env
+            )
             extra_kwargs = {}
 
             if self.reader == XarrayReader:
-                extra_kwargs['request_options'] = request.headers
+                extra_kwargs["request_options"] = request.headers
 
             with rasterio.Env(**updated_env):
                 with self.reader(
@@ -1825,11 +1862,13 @@ class MultiBaseTilerFactory(TilerFactory):
             if isinstance(fc, Feature):
                 fc = FeatureCollection(type="FeatureCollection", features=[geojson])
 
-            resolved_path, updated_env = resolve_src_path_and_credentials(src_path, request, env)
+            resolved_path, updated_env = resolve_src_path_and_credentials(
+                src_path, request, env
+            )
             extra_kwargs = {}
 
             if self.reader == XarrayReader:
-                extra_kwargs['request_options'] = request.headers
+                extra_kwargs["request_options"] = request.headers
 
             with rasterio.Env(**updated_env):
                 with self.reader(
@@ -1909,11 +1948,13 @@ class MultiBandTilerFactory(TilerFactory):
             env=Depends(self.environment_dependency),
         ):
             """Return dataset's basic info."""
-            resolved_path, updated_env = resolve_src_path_and_credentials(src_path, request, env)
+            resolved_path, updated_env = resolve_src_path_and_credentials(
+                src_path, request, env
+            )
             extra_kwargs = {}
 
             if self.reader == XarrayReader:
-                extra_kwargs['request_options'] = request.headers
+                extra_kwargs["request_options"] = request.headers
 
             with rasterio.Env(**updated_env):
                 with self.reader(
@@ -1942,11 +1983,13 @@ class MultiBandTilerFactory(TilerFactory):
             env=Depends(self.environment_dependency),
         ):
             """Return dataset's basic info as a GeoJSON feature."""
-            resolved_path, updated_env = resolve_src_path_and_credentials(src_path, request, env)
+            resolved_path, updated_env = resolve_src_path_and_credentials(
+                src_path, request, env
+            )
             extra_kwargs = {}
 
             if self.reader == XarrayReader:
-                extra_kwargs['request_options'] = request.headers
+                extra_kwargs["request_options"] = request.headers
 
             with rasterio.Env(**updated_env):
                 with self.reader(
@@ -1974,11 +2017,13 @@ class MultiBandTilerFactory(TilerFactory):
             env=Depends(self.environment_dependency),
         ):
             """Return a list of supported bands."""
-            resolved_path, updated_env = resolve_src_path_and_credentials(src_path, request, env)
+            resolved_path, updated_env = resolve_src_path_and_credentials(
+                src_path, request, env
+            )
             extra_kwargs = {}
 
             if self.reader == XarrayReader:
-                extra_kwargs['request_options'] = request.headers
+                extra_kwargs["request_options"] = request.headers
 
             with rasterio.Env(**updated_env):
                 with self.reader(
@@ -2015,11 +2060,13 @@ class MultiBandTilerFactory(TilerFactory):
             env=Depends(self.environment_dependency),
         ):
             """Get Dataset statistics."""
-            resolved_path, updated_env = resolve_src_path_and_credentials(src_path, request, env)
+            resolved_path, updated_env = resolve_src_path_and_credentials(
+                src_path, request, env
+            )
             extra_kwargs = {}
 
             if self.reader == XarrayReader:
-                extra_kwargs['request_options'] = request.headers
+                extra_kwargs["request_options"] = request.headers
 
             with rasterio.Env(**updated_env):
                 with self.reader(
@@ -2079,11 +2126,13 @@ class MultiBandTilerFactory(TilerFactory):
             if isinstance(fc, Feature):
                 fc = FeatureCollection(type="FeatureCollection", features=[geojson])
 
-            resolved_path, updated_env = resolve_src_path_and_credentials(src_path, request, env)
+            resolved_path, updated_env = resolve_src_path_and_credentials(
+                src_path, request, env
+            )
             extra_kwargs = {}
 
             if self.reader == XarrayReader:
-                extra_kwargs['request_options'] = request.headers
+                extra_kwargs["request_options"] = request.headers
 
             with rasterio.Env(**updated_env):
                 with self.reader(

--- a/src/titiler/core/titiler/core/factory.py
+++ b/src/titiler/core/titiler/core/factory.py
@@ -960,7 +960,10 @@ class TilerFactory(BaseFactory):
             scale: Annotated[
                 int,
                 Field(
-                    gt=0, le=4, description="Tile size scale. 1=256x256, 2=512x512..."
+                    gt=0,
+                    le=4,
+                    description="Tile size scale. 1=256x256, 2=512x512...",
+                    example="2"
                 ),
             ] = 1,
             format: Annotated[
@@ -1367,8 +1370,8 @@ class TilerFactory(BaseFactory):
         )
         def point(
             request: Request,
-            lon: Annotated[float, Path(description="Longitude")],
-            lat: Annotated[float, Path(description="Latitude")],
+            lon: Annotated[float, Path(description="Longitude", example="-0.1")],
+            lat: Annotated[float, Path(description="Latitude", example="51.5")],
             src_path=Depends(self.path_dependency),
             reader_params=Depends(self.reader_dependency),
             coord_crs=Depends(CoordCRSParams),
@@ -1478,10 +1481,18 @@ class TilerFactory(BaseFactory):
         )
         def bbox_image(
             request: Request,
-            minx: Annotated[float, Path(description="Bounding box min X")],
-            miny: Annotated[float, Path(description="Bounding box min Y")],
-            maxx: Annotated[float, Path(description="Bounding box max X")],
-            maxy: Annotated[float, Path(description="Bounding box max Y")],
+            minx: Annotated[
+                float, Path(description="Bounding box min X", example="-0.15")
+            ],
+            miny: Annotated[
+                float, Path(description="Bounding box min Y", example="51.5")
+            ],
+            maxx: Annotated[
+                float, Path(description="Bounding box max X", example="-0.1")
+            ],
+            maxy: Annotated[
+                float, Path(description="Bounding box max Y", example="51.5")
+            ],
             format: Annotated[
                 ImageType,
                 "Default will be automatically defined if the output image needs a mask (png) or not (jpeg).",
@@ -2419,12 +2430,14 @@ class ColorMapFactory(BaseFactory):
                 Optional[int],
                 Query(
                     description="Image Height (default to 20px for horizontal or 256px for vertical).",
+                    example="256px",
                 ),
             ] = None,
             width: Annotated[
                 Optional[int],
                 Query(
                     description="Image Width (default to 256px for horizontal or 20px for vertical).",
+                    example="256px",
                 ),
             ] = None,
         ):

--- a/src/titiler/xarray/titiler/xarray/dependencies.py
+++ b/src/titiler/xarray/titiler/xarray/dependencies.py
@@ -37,7 +37,7 @@ class XarrayIOParams(DefaultDependency):
 class XarrayDsParams(DefaultDependency):
     """Xarray Dataset Options."""
 
-    variable: Annotated[str, Query(description="Xarray Variable name")]
+    variable: Annotated[str, Query(description="Xarray Variable name", example="band1")]
 
     drop_dim: Annotated[
         Optional[str],
@@ -65,7 +65,7 @@ class CompatXarrayParams(XarrayIOParams):
     it would fail without the variable query-parameter set.
     """
 
-    variable: Annotated[Optional[str], Query(description="Xarray Variable name")] = None
+    variable: Annotated[Optional[str], Query(description="Xarray Variable name", example="band1")] = None
 
     drop_dim: Annotated[
         Optional[str],


### PR DESCRIPTION
Updated default values for TiTiler are as follows:

- Dataset URL: The URL to the dataset (raster file or data asset) - https://example.com/dataset.tif
- CRS (Coordinate Reference System): The coordinate system used (e.g., EPSG:4326 for WGS84 Lat/Lon) - EPSG:4326
- X Y Z: Tile coordinates for map tiles, TiTiler follows a standard XYZ tile scheme - X 0 Y 0 Z 12
- Scale: The resolution or zoom level at which the data should be rendered - 5000
- Latitude, Longitude: Geographic coordinates indicating the specific location for the query - 51.5 -0.1
- minx, miny, maxx, maxy: Bounding box coordinates defining the spatial extent (in the CRS) - -0.15 51.5 -0.1 51.5
- Height, Width: Pixel dimensions for the image - 256px 256px
- XArray Variable Name: Variable name within an xarray dataset (found in multidimensional arrays e.g., ZARR, NetCDF, Kerchunk) - band1