### PR TITLE
107 refactor option passing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG PYTHON_VERSION=3.12
 
-FROM bitnami/python:${PYTHON_VERSION}
+FROM bitnamilegacy/python:${PYTHON_VERSION}
 RUN apt update && apt upgrade -y \
   && apt install curl -y \
   && rm -rf /var/lib/apt/lists/*

--- a/src/titiler/core/titiler/core/factory.py
+++ b/src/titiler/core/titiler/core/factory.py
@@ -32,7 +32,13 @@ from pydantic import Field
 from rio_tiler.colormap import ColorMaps
 from rio_tiler.colormap import cmap as default_cmap
 from rio_tiler.constants import WGS84_CRS
-from rio_tiler.io import BaseReader, MultiBandReader, MultiBaseReader, Reader
+from rio_tiler.io import (
+    BaseReader,
+    MultiBandReader,
+    MultiBaseReader,
+    Reader,
+    STACReader,
+)
 from rio_tiler.models import Bounds, ImageData, Info
 from rio_tiler.types import ColorMapType
 from rio_tiler.utils import CRS_to_uri, CRS_to_urn
@@ -86,7 +92,6 @@ from titiler.core.resources.responses import GeoJSONResponse, JSONResponse, XMLR
 from titiler.core.routing import EndpointScope
 from titiler.core.utils import bounds_to_geometry, render_image
 from titiler.xarray.io import Reader as XarrayReader
-from rio_tiler.io import STACReader
 
 jinja2_env = jinja2.Environment(
     loader=jinja2.ChoiceLoader([jinja2.PackageLoader(__package__, "templates")])
@@ -898,7 +903,9 @@ class TilerFactory(BaseFactory):
                 extra_kwargs["request_options"] = request.headers
 
             if self.reader == STACReader:
-                extra_kwargs["fetch_options"] = {"headers": {"Authorization": request.headers.get("Authorization")}}
+                extra_kwargs["fetch_options"] = {
+                    "headers": {"Authorization": request.headers.get("Authorization")}
+                }
 
             with rasterio.Env(**updated_env):
                 with self.reader(

--- a/src/titiler/core/titiler/core/factory.py
+++ b/src/titiler/core/titiler/core/factory.py
@@ -1708,7 +1708,7 @@ class MultiBaseTilerFactory(TilerFactory):
             resolved_path, updated_env = resolve_src_path_and_credentials(
                 src_path, request, env
             )
-            extra_kwargs = configure_reader(self.reader, request)
+            extra_kwargs, self.reader = configure_reader(self.reader, request)
 
             with rasterio.Env(**updated_env):
                 with self.reader(
@@ -1740,7 +1740,7 @@ class MultiBaseTilerFactory(TilerFactory):
             resolved_path, updated_env = resolve_src_path_and_credentials(
                 src_path, request, env
             )
-            extra_kwargs = configure_reader(self.reader, request)
+            extra_kwargs, self.reader = configure_reader(self.reader, request)
 
             with rasterio.Env(**updated_env):
                 with self.reader(
@@ -1771,7 +1771,7 @@ class MultiBaseTilerFactory(TilerFactory):
             resolved_path, updated_env = resolve_src_path_and_credentials(
                 src_path, request, env
             )
-            extra_kwargs = configure_reader(self.reader, request)
+            extra_kwargs, self.reader = configure_reader(self.reader, request)
 
             with rasterio.Env(**updated_env):
                 with self.reader(
@@ -1811,7 +1811,7 @@ class MultiBaseTilerFactory(TilerFactory):
             resolved_path, updated_env = resolve_src_path_and_credentials(
                 src_path, request, env
             )
-            extra_kwargs = configure_reader(self.reader, request)
+            extra_kwargs, self.reader = configure_reader(self.reader, request)
 
             with rasterio.Env(**updated_env):
                 with self.reader(
@@ -1855,7 +1855,7 @@ class MultiBaseTilerFactory(TilerFactory):
             resolved_path, updated_env = resolve_src_path_and_credentials(
                 src_path, request, env
             )
-            extra_kwargs = configure_reader(self.reader, request)
+            extra_kwargs, self.reader = configure_reader(self.reader, request)
 
             with rasterio.Env(**updated_env):
                 with self.reader(
@@ -1918,7 +1918,7 @@ class MultiBaseTilerFactory(TilerFactory):
             resolved_path, updated_env = resolve_src_path_and_credentials(
                 src_path, request, env
             )
-            extra_kwargs = configure_reader(self.reader, request)
+            extra_kwargs, self.reader = configure_reader(self.reader, request)
 
             with rasterio.Env(**updated_env):
                 with self.reader(

--- a/src/titiler/core/titiler/core/factory.py
+++ b/src/titiler/core/titiler/core/factory.py
@@ -86,6 +86,7 @@ from titiler.core.resources.responses import GeoJSONResponse, JSONResponse, XMLR
 from titiler.core.routing import EndpointScope
 from titiler.core.utils import bounds_to_geometry, render_image
 from titiler.xarray.io import Reader as XarrayReader
+from rio_tiler.io import STACReader
 
 jinja2_env = jinja2.Environment(
     loader=jinja2.ChoiceLoader([jinja2.PackageLoader(__package__, "templates")])
@@ -895,6 +896,9 @@ class TilerFactory(BaseFactory):
 
             if self.reader == XarrayReader:
                 extra_kwargs["request_options"] = request.headers
+
+            if self.reader == STACReader:
+                extra_kwargs["fetch_options"] = {"headers": {"Authorization": request.headers.get("Authorization")}}
 
             with rasterio.Env(**updated_env):
                 with self.reader(

--- a/src/titiler/core/titiler/core/factory.py
+++ b/src/titiler/core/titiler/core/factory.py
@@ -141,9 +141,9 @@ def configure_reader(
 
     if reader == STACReader:
         reader = RewriteSTACReader
-        extra_kwargs["fetch_options"] = {
-            "headers": {"Authorization": request.headers.get("Authorization")}
-        }
+        auth_header = request.headers.get("Authorization")
+        if auth_header:
+            extra_kwargs["fetch_options"] = {"headers": {"Authorization": auth_header}}
 
     return extra_kwargs, reader
 

--- a/src/titiler/core/titiler/core/factory.py
+++ b/src/titiler/core/titiler/core/factory.py
@@ -947,12 +947,12 @@ class TilerFactory(BaseFactory):
             resolved_path, updated_env = resolve_src_path_and_credentials(
                 src_path, request, env
             )
-            extra_kwargs, self.reader = configure_reader(
+            extra_kwargs, reader_cls = configure_reader(
                 self.reader, request, {"tms": tms}
             )
 
             with rasterio.Env(**updated_env):
-                with self.reader(
+                with reader_cls(
                     resolved_path, **extra_kwargs, **reader_params.as_dict()
                 ) as src_dst:
                     image = src_dst.tile(

--- a/src/titiler/core/titiler/core/factory.py
+++ b/src/titiler/core/titiler/core/factory.py
@@ -1708,10 +1708,10 @@ class MultiBaseTilerFactory(TilerFactory):
             resolved_path, updated_env = resolve_src_path_and_credentials(
                 src_path, request, env
             )
-            extra_kwargs, self.reader = configure_reader(self.reader, request)
+            extra_kwargs, reader_cls = configure_reader(self.reader, request)
 
             with rasterio.Env(**updated_env):
-                with self.reader(
+                with reader_cls(
                     resolved_path, **extra_kwargs, **reader_params.as_dict()
                 ) as src_dst:
                     return src_dst.info(**asset_params.as_dict())
@@ -1740,10 +1740,10 @@ class MultiBaseTilerFactory(TilerFactory):
             resolved_path, updated_env = resolve_src_path_and_credentials(
                 src_path, request, env
             )
-            extra_kwargs, self.reader = configure_reader(self.reader, request)
+            extra_kwargs, reader_cls = configure_reader(self.reader, request)
 
             with rasterio.Env(**updated_env):
-                with self.reader(
+                with reader_cls(
                     resolved_path, **extra_kwargs, **reader_params.as_dict()
                 ) as src_dst:
                     bounds = src_dst.get_geographic_bounds(crs or WGS84_CRS)
@@ -1771,10 +1771,10 @@ class MultiBaseTilerFactory(TilerFactory):
             resolved_path, updated_env = resolve_src_path_and_credentials(
                 src_path, request, env
             )
-            extra_kwargs, self.reader = configure_reader(self.reader, request)
+            extra_kwargs, reader_cls = configure_reader(self.reader, request)
 
             with rasterio.Env(**updated_env):
-                with self.reader(
+                with reader_cls(
                     resolved_path, **extra_kwargs, **reader_params.as_dict()
                 ) as src_dst:
                     return src_dst.assets
@@ -1811,10 +1811,10 @@ class MultiBaseTilerFactory(TilerFactory):
             resolved_path, updated_env = resolve_src_path_and_credentials(
                 src_path, request, env
             )
-            extra_kwargs, self.reader = configure_reader(self.reader, request)
+            extra_kwargs, reader_cls = configure_reader(self.reader, request)
 
             with rasterio.Env(**updated_env):
-                with self.reader(
+                with reader_cls(
                     resolved_path, **extra_kwargs, **reader_params.as_dict()
                 ) as src_dst:
                     return src_dst.statistics(
@@ -1855,10 +1855,10 @@ class MultiBaseTilerFactory(TilerFactory):
             resolved_path, updated_env = resolve_src_path_and_credentials(
                 src_path, request, env
             )
-            extra_kwargs, self.reader = configure_reader(self.reader, request)
+            extra_kwargs, reader_cls = configure_reader(self.reader, request)
 
             with rasterio.Env(**updated_env):
-                with self.reader(
+                with reader_cls(
                     resolved_path, **extra_kwargs, **reader_params.as_dict()
                 ) as src_dst:
                     # Default to all available assets
@@ -1918,10 +1918,10 @@ class MultiBaseTilerFactory(TilerFactory):
             resolved_path, updated_env = resolve_src_path_and_credentials(
                 src_path, request, env
             )
-            extra_kwargs, self.reader = configure_reader(self.reader, request)
+            extra_kwargs, reader_cls = configure_reader(self.reader, request)
 
             with rasterio.Env(**updated_env):
-                with self.reader(
+                with reader_cls(
                     resolved_path, **extra_kwargs, **reader_params.as_dict()
                 ) as src_dst:
                     # Default to all available assets


### PR DESCRIPTION
Part of https://github.com/EO-DataHub/eodhp-sparkgeo-pm/issues/107.
When the [initial test](https://github.com/EO-DataHub/titiler/pull/11) of the fix checks out, we will apply the same fix to the rest of endpoints that will potentially use `STACReader`.


### URLs being rewritten

It turns out URL are being rewritten if the original URL matches certain pattern such as:
```python
def rewrite_https_to_s3_if_needed(url: str) -> Tuple[str, Optional[str]]:
    """
    Converts certain HTTPS URLs to S3 URLs if they match known workspace patterns.
    Returns the rewritten S3 path and the subdomain or workspace name, if applicable.
    """
    if match := EODH_WORKSPACE_URL_PATTERN.match(url):
        return (
            f"s3://{match['bucket']}/{match['subdomain']}/{match['key']}",
            match["subdomain"],
        )
    if match := EODH_S3_HTTPS_PATTERN.match(url):
        return (
            f"s3://{match['bucket']}/{match['workspace']}/{match['key']}",
            match["workspace"],
        )
    return url, None
```
See: 
- https://github.com/EO-DataHub/titiler/blob/48bc51d7b36434c9495ce301dc8babfba2eabead/src/titiler/core/titiler/core/auth.py#L69-L84
- https://github.com/EO-DataHub/titiler/blob/48bc51d7b36434c9495ce301dc8babfba2eabead/src/titiler/core/titiler/core/auth.py#L147
- https://github.com/EO-DataHub/titiler/blob/48bc51d7b36434c9495ce301dc8babfba2eabead/src/titiler/core/titiler/core/auth.py#L164

This cannot be applied to STAC item's asset urls the way the current code is doing it. 
To work around this, we subclass `STACReader` and apply `rewrite_https_to_s3_if_needed` from there:

```python
class RewriteSTACReader(STACReader):
    """
    Rewritten STACReader to rewrite the href to the S3 URL.
    """

    def _get_asset_info(self, asset: str):
        info = super()._get_asset_info(asset)
        url = info["url"]
        resolved_path, _ = rewrite_https_to_s3_if_needed(url)
        info["url"] = resolved_path
        return info
```

### Testing

To test, we use the following values:
```yaml
tile_url: https://test.eodatahub.org.uk/titiler/core/stac/tiles/WebMercatorQuad/12/2049/1336@1x
    url: https://test.eodatahub.org.uk/api/catalogue/stac/catalogs/user/catalogs/sg2/catalogs/commercial-data/catalogs/airbus/collections/airbus_phr_data/items/ds_phr1a_201805011119343_fr1_px_e000n52_0420_02024_7331862101
    title: Purchased Data (Full Resolution)
    assets: primaryAsset-ortho_R1C1
    auth: true
    id: purchased
    __requiresAuth: true
```

This is what it looks like using `curl`:
```bash

$ curl --request GET \
  --url 'https://test.eodatahub.org.uk/titiler/core/stac/tiles/WebMercatorQuad/12/2049/1336@1x?url=https%3A%2F%2Ftest.eodatahub.org.uk%2Fapi%2Fcatalogue%2Fstac%2Fcatalogs%2Fuser%2Fcatalogs%2Fsg2%2Fcatalogs%2Fcommercial-data%2Fcatalogs%2Fairbus%2Fcollections%2Fairbus_phr_data%2Fitems%2Fds_phr1a_201805011119343_fr1_px_e000n52_0420_02024_7331862101&title=Purchased%20Data%20(Full%20Resolution)&assets=primaryAsset-ortho_R1C1&auth=true&id=purchased&__requiresAuth=true' \
  --header 'authorization: Bearer {API_KEY_GOES_HERE}'
```